### PR TITLE
Remove mmc partition hiding

### DIFF
--- a/drivers/mmc/core/mmc.c
+++ b/drivers/mmc/core/mmc.c
@@ -354,7 +354,9 @@ static int mmc_read_ext_csd(struct mmc_card *card, u8 *ext_csd)
 				part_size = ext_csd[EXT_CSD_BOOT_MULT] << 17;
 				mmc_part_add(card, part_size,
 					EXT_CSD_PART_CONFIG_ACC_BOOT0 + idx,
-					"boot%d", idx, true,
+// winsock - enable write to second boot partition. See: https://devtalk.nvidia.com/default/topic/802197 comment #3
+					"boot%d", idx, (idx < 1) ? true : false,
+// winsock - end
 					MMC_BLK_DATA_AREA_BOOT);
 			}
 		}

--- a/drivers/mmc/host/sdhci-tegra.c
+++ b/drivers/mmc/host/sdhci-tegra.c
@@ -4332,9 +4332,10 @@ static int sdhci_tegra_probe(struct platform_device *pdev)
 		host->mmc->caps |= MMC_CAP_NONREMOVABLE;
 	}
 	host->mmc->pm_flags |= MMC_PM_IGNORE_PM_NOTIFY;
-
+// winsock - Disable to access boot partitons and the bct data
 	/* disable access to boot partitions */
-	host->mmc->caps2 |= MMC_CAP2_BOOTPART_NOACC;
+//	host->mmc->caps2 |= MMC_CAP2_BOOTPART_NOACC;
+// winsock - end change
 
 #if !defined(CONFIG_ARCH_TEGRA_2x_SOC) && !defined(CONFIG_ARCH_TEGRA_3x_SOC)
 	if (soc_data->nvquirks & NVQUIRK_ENABLE_HS200)


### PR DESCRIPTION
This patch removes nvidia's hiding of tegra critical mmc partitions. This will allow dumping of mmcblk0boot0 and mmcblk0boot1 (And others most likely, those were the two I wanted however) I built and tested the zImage on my shield tablet (wx_na_wf).

Information was found at:
https://devtalk.nvidia.com/default/topic/802197/post/4425615/#4425615
